### PR TITLE
PlaywrightによるE2Eテストフレームワークの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "index.js",
 	"scripts": {
 		"check": "pnpm -r check",
-		"build": "pnpm -r build"
+		"build": "pnpm -r build",
+		"e2e": "pnpm --filter e2e test"
 	},
 	"keywords": [],
 	"author": "",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "e2e",
+	"version": "1.0.0",
+	"type": "module",
+	"description": "E2E tests for Tasko",
+	"scripts": {
+		"check": "biome check . --write && tsc -p tsconfig.json --noEmit",
+		"test": "node scripts/run-e2e.js",
+		"test:ui": "playwright test --ui",
+		"test:debug": "playwright test --debug"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.55.0",
+		"@types/node": "~24.3.3",
+		"typescript": "~5.8.3"
+	}
+}

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./tests",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: "list",
+	use: {
+		baseURL: "http://localhost:3000",
+		trace: "on-first-retry",
+	},
+
+	projects: [
+		{
+			name: "chromium",
+			use: {
+				...devices["Desktop Chrome"],
+				headless: true,
+			},
+		},
+	],
+});

--- a/packages/e2e/scripts/run-e2e.js
+++ b/packages/e2e/scripts/run-e2e.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { promisify } from "node:util";
+
+const sleep = promisify(setTimeout);
+
+let serverProcess = null;
+
+async function runCommand(command, args = [], options = {}) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			stdio: "inherit",
+			shell: true,
+			...options,
+		});
+
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error(`Command failed with exit code ${code}`));
+			}
+		});
+
+		child.on("error", reject);
+	});
+}
+
+async function startServer() {
+	return new Promise((resolve, reject) => {
+		console.log("Starting server...");
+		serverProcess = spawn("node", ["dist/index.js"], {
+			cwd: "../../packages/backend",
+			stdio: "pipe",
+		});
+
+		serverProcess.stdout.on("data", (data) => {
+			const output = data.toString();
+			console.log(output);
+			if (
+				output.includes("Server running on port 3000") ||
+				output.includes("listening on port 3000")
+			) {
+				resolve();
+			}
+		});
+
+		serverProcess.stderr.on("data", (data) => {
+			console.error(data.toString());
+		});
+
+		serverProcess.on("error", reject);
+
+		// Fallback: resolve after 5 seconds if no specific message is found
+		setTimeout(resolve, 5000);
+	});
+}
+
+function stopServer() {
+	if (serverProcess) {
+		console.log("Stopping server...");
+		serverProcess.kill("SIGTERM");
+		serverProcess = null;
+	}
+}
+
+async function main() {
+	try {
+		console.log("Building frontend...");
+		await runCommand("pnpm", ["--filter", "frontend", "build"], {
+			cwd: "../..",
+		});
+
+		console.log("Building backend...");
+		await runCommand("pnpm", ["--filter", "backend", "build"], {
+			cwd: "../..",
+		});
+
+		await startServer();
+		await sleep(2000); // Give server extra time to fully start
+
+		console.log("Running E2E tests...");
+		await runCommand("npx", ["playwright", "test"]);
+
+		console.log("E2E tests completed successfully!");
+	} catch (error) {
+		console.error("E2E workflow failed:", error.message);
+		process.exit(1);
+	} finally {
+		stopServer();
+	}
+}
+
+// Handle process termination
+process.on("SIGINT", () => {
+	console.log("Received SIGINT, cleaning up...");
+	stopServer();
+	process.exit(0);
+});
+
+process.on("SIGTERM", () => {
+	console.log("Received SIGTERM, cleaning up...");
+	stopServer();
+	process.exit(0);
+});
+
+main();

--- a/packages/e2e/tests/homepage.spec.ts
+++ b/packages/e2e/tests/homepage.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+
+test("homepage should display correctly", async ({ page }) => {
+	await page.goto("/");
+
+	// ページタイトルを確認
+	await expect(page).toHaveTitle(/Vite \+ React \+ TS/);
+
+	// ページが正常にロードされていることを確認
+	await expect(page.locator("body")).toBeVisible();
+
+	// 基本的なコンテンツが表示されていることを確認
+	await expect(page.locator("h1, h2, h3").first()).toBeVisible();
+});

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.4
         version: 2.2.4
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.55.0
+      '@types/node':
+        specifier: ~24.3.3
+        version: 24.3.3
 
   packages/backend:
     dependencies:
@@ -482,6 +488,11 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1075,6 +1086,11 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1429,6 +1445,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2145,6 +2171,10 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -2775,6 +2805,9 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3166,6 +3199,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.6:
     dependencies:


### PR DESCRIPTION
## 概要
Chrome専用のPlaywright E2Eテストフレームワークを追加しました。

## 実装した内容
- Playwright Chrome専用設定でのE2Eテストインストール
- packages/e2e ワークスペース構造の構築
- ホームページ表示テストの作成
- ヘッドレスモードでのブラウザ起動回避設定
- pnpm e2eコマンドでのテスト実行統合
- BiomeおよびTypeScriptチェックの対応

## アプローチの選択理由
packages/e2e構造を採用した理由は、frontend/backendと統一された管理体系を維持し、E2E専用の依存関係を分離できるためです。pnpmワークスペースの恩恵を受け、ルートからの統一コマンド実行が可能になります。

Chrome専用設定により、テスト環境の一貫性を保ちつつ、ヘッドレスモードでCI/CD環境での自動実行にも対応しています。

🤖 Generated with [Claude Code](https://claude.ai/code)